### PR TITLE
Fix issue where next button disappears upon reload

### DIFF
--- a/inst/main.js
+++ b/inst/main.js
@@ -184,6 +184,9 @@ $.extend(wizard, {
       
       $(el).attr("data-active-step", 0);
 
+      // display next button on wizard reset
+      document.querySelector('.wizard-buttons button.next').style.display = 'block';
+
       // inform shiny about step change
       $(steps[current]).trigger("hidden");
         $(steps[0]).trigger("shown");


### PR DESCRIPTION
This pull request fixes an issue where the next button in the wizard disappears upon reloading the page. The issue was caused by the next button not being displayed when the wizard is reset. This PR adds code to display the next button on wizard reset, ensuring that it is always visible to the user.