### PR TITLE
Replace data-title with data-step-id

### DIFF
--- a/R/wizard.R
+++ b/R/wizard.R
@@ -201,13 +201,20 @@ wizard <- function(
 #' @return wizard step html
 #' @export
 wizard_step <- function(
-    ...,
-    step_title = NULL,
-    session = shiny::getDefaultReactiveDomain()) {
+  ...,
+  step_title = NULL,
+  step_id = NULL,
+  session = shiny::getDefaultReactiveDomain()) {
+  
+  if (is.null(step_id)) {
+    stop("Step id must be provided")
+  }
+
   htmltools::div(
     ...,
     class = "wizard-step",
     "data-title" = step_title,
+    "data-step-id" = step_id,
     session = session
   )
 }

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -12,18 +12,22 @@ ui <- fluidPage(
       # start sequence of steps
       wizard_step(
         step_title = "Hello tag",
+        step_id ="step-helo",
         shiny::h5("hello, this is step 0.")
       ),
       wizard_step(
         step_title = "Numeric input",
+        step_id ="step-input",
         shiny::numericInput("number", "Select a number", value = 30, min = 20, max = 100)
       ),
       wizard_step(
         step_title = "Plot output from input",
+        step_id = "step-output",
         plotOutput("plot")
       ),
       wizard_step(
-        shiny::h5("No step title defined. This is the last step.")
+        shiny::h5("No step title defined. This is the last step."),
+        step_id = "step-last"
       )
     )
 )
@@ -41,6 +45,10 @@ server <- function(input, output, session) {
   # show the wizard
   observeEvent(input$show_wizard, {
     wizard_show("my_modal")
+  })
+
+  observeEvent(input$my_modal, {
+    print(input$my_modal)
   })
 }
 

--- a/inst/main.js
+++ b/inst/main.js
@@ -53,7 +53,7 @@ $.extend(wizard, {
   },
 
   getValue: function(el) {
-    cur_step = $(el).attr("data-title");
+    cur_step = $(el).attr("data-step-id");
   
     return cur_step;
   },
@@ -123,6 +123,7 @@ $.extend(wizard, {
         }
 
         var title = $(steps[next]).data("title");
+        var step_id = $(steps[next]).data("step-id");
 
         title = title || null;
 
@@ -131,6 +132,7 @@ $.extend(wizard, {
         }
 
         $(el).attr("data-title", title);
+        $(el).attr("data-step-id", step_id);
 
         callback(false);
       });
@@ -157,6 +159,7 @@ $.extend(wizard, {
 
         // get data-title for next step
         var title = $(steps[next]).data("title");
+        var step_id = $(steps[next]).data("step-id");
 
         // if title is undefined, set it to "Step n"
         title = title || null;
@@ -165,7 +168,7 @@ $.extend(wizard, {
         }
 
         $(el).attr("data-title", title);
-
+        $(el).attr("data-step-id", step_id);
 
         callback(false);
       });
@@ -193,12 +196,16 @@ $.extend(wizard, {
 
       // return title to first step
       var steps = $(el).find(".wizard-content .wizard-step");
+      var step_id = $(steps[0]).data("step-id");
+
       var title = $(steps[0]).data("title");
       title = title || null;
       if (title === null) {
         title = "Step " + $(steps[0]).data("step");
       }
       $(el).attr("data-title", title);
+      
+      $(el).attr("data-step-id", step_id);
 
       callback(false);
     });

--- a/inst/main.js
+++ b/inst/main.js
@@ -131,7 +131,6 @@ $.extend(wizard, {
           title = "Step " + $(steps[next]).data("step");
         }
 
-        $(el).attr("data-title", title);
         $(el).attr("data-step-id", step_id);
 
         callback(false);
@@ -155,19 +154,9 @@ $.extend(wizard, {
 
         $(steps[current]).trigger("hidden");
         $(steps[next]).trigger("shown");
-        
 
-        // get data-title for next step
-        var title = $(steps[next]).data("title");
         var step_id = $(steps[next]).data("step-id");
 
-        // if title is undefined, set it to "Step n"
-        title = title || null;
-        if (title === null) {
-          title = "Step " + $(steps[next]).data("step");
-        }
-
-        $(el).attr("data-title", title);
         $(el).attr("data-step-id", step_id);
 
         callback(false);
@@ -197,13 +186,6 @@ $.extend(wizard, {
       // return title to first step
       var steps = $(el).find(".wizard-content .wizard-step");
       var step_id = $(steps[0]).data("step-id");
-
-      var title = $(steps[0]).data("title");
-      title = title || null;
-      if (title === null) {
-        title = "Step " + $(steps[0]).data("step");
-      }
-      $(el).attr("data-title", title);
       
       $(el).attr("data-step-id", step_id);
 


### PR DESCRIPTION
This pull request adds step_id parameter as substitute of title to control the wizard via shiny.